### PR TITLE
Remove duplicated `@​deprecated` tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,21 +160,6 @@ function count()
  */
 ```
 
-@deprecated
-
-```php
-/**
- * @deprecated
- * @deprecated 1.0.0
- * @deprecated No longer used by internal code and not recommended.
- * @deprecated 1.0.0 No longer used by internal code and not recommended.
- */
-function count()
-{
-	...
-}
-```
-
 @global
 
 This tag is not included in phpDocumentor 2.0

--- a/index.html
+++ b/index.html
@@ -232,19 +232,6 @@ function count()
 * @filesource
 */</code></pre>
 
-                      <h4>@deprecated</h4>
-<pre><code>/**
-* @deprecated
-* @deprecated 1.0.0
-* @deprecated No longer used by internal code and not recommended.
-* @deprecated 1.0.0 No longer used by internal code and not recommended.
-*/
-
-function count()
-{
-  <...>
-}</code></pre>
-
                       <h4>@global</h4>
                       <h5>This tag is not included in phpDocumentor 2.0</h5>
 <pre><code>/**


### PR DESCRIPTION
Two sections about the `@​deprecated` tag appeared in this cheatsheet.